### PR TITLE
[Feature] Add parameter to enable returning of only emojis

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,14 +158,15 @@ Returns all emojis associated with each keyword.
 }
 ```
 
-### `searchByGroup(group: string)`
+### `searchByGroup(group: string, onlyEmoji?: boolean | undefined)`
 Returns all emojis in the given group.
 
-Parameter given can either be a partial group name (`"smi"` for `"Smileys & Emoticon"`) or a full group name (`"smileys & emoticon"` for `"Smileys & Emoticon"`) and is ***NOT*** case-sensitive.
+- `group` : Can either be a partial group name (`"smi"` for `"Smileys & Emoticon"`) or a full group name (`"smileys & emoticon"` for `"Smileys & Emoticon"`) and is ***NOT*** case-sensitive.
+- `onlyEmoji` : Optional. `true` to only return the emoji, `false` to return all information as well as the emoji. Default is `false`.
 
-*Example:*
+*Examples:*
 ```js
-> EmojiSet.searchByGroup('flags')
+> EmojiSet.searchByGroup('flags', false)
 [
   {
     emoji: '🏁',
@@ -204,15 +205,21 @@ Parameter given can either be a partial group name (`"smi"` for `"Smileys & Emot
   }
 ]
 ```
+```js
+> EmojiSet.searchByGroup('flags', true)
+[ '🏁', '🚩', '🎌', '🏴', '🏳️', '🏳️‍🌈', '🏴‍☠️' ]
+```
 
-### `searchByKeyword(keyword: string)`
+### `searchByKeyword(keyword: string, first?: boolean | undefined, onlyEmoji?: boolean | undefined)`
 Returns all emojis relating to the given keyword.
 
-Parameter given can either be a partial keyword (`"perf"` for `"perfect"`) or a full keyword (`"perfect"`).
+- `keyword` : Can either be a partial keyword (`"perf"` for `"perfect"`) or a full keyword (`"perfect"`) and is ***NOT*** case sensitive.
+- `first` : Optional. `true` to return the first match, `false` to return all matches. Default is `true`.
+- `onlyEmoji` : Optional. `true` to only return the emoji, `false` to return all information as well as the emoji. Default is `false`.
 
-*Example:*
+*Examples:*
 ```js
-> EmojiSet.searchByKeyword('perfect')
+> EmojiSet.searchByKeyword('perf', true, false)
 {
   '💯': {
     name: 'hundred points',
@@ -225,4 +232,37 @@ Parameter given can either be a partial keyword (`"perf"` for `"perfect"`) or a 
     group: 'People & Body'
   }
 }
+```
+```js
+> EmojiSet.searchByKeyword('perf', false, false)
+{
+  '💯': {
+    name: 'hundred points',
+    code: 'hundred_points',
+    group: 'Smileys & Emotion'
+  },
+  '👌': {
+    name: 'OK hand',
+    code: 'ok_hand',
+    group: 'People & Body'
+  },
+  '👯': {
+    name: 'people with bunny ears',
+    code: 'people_with_bunny_ears',
+    group: 'People & Body'
+  },
+  '🤹': {
+    name: 'person juggling',
+    code: 'person_juggling',
+    group: 'People & Body'
+  }
+}
+```
+```js
+> EmojiSet.searchByKeyword('perf', true, true)
+[ '💯', '👌' ]
+```
+```js
+> EmojiSet.searchByKeyword('perf', false, true)
+[ '💯', '👌', '👯', '🤹' ]
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # emoji-set
 
 <p>
-	<img src="https://github.com/chapmankyle/emoji-set/actions/workflows/test.yml/badge.svg?branch=master" alt="Test Status">
-	<img src="https://img.shields.io/npm/v/emoji-set" alt="Version">
-	<img src="https://img.shields.io/bundlephobia/min/emoji-set" alt="Size">
-	<a href="https://standardjs.com">
-		<img src="https://img.shields.io/badge/code%20style-standard-%23f3df49" alt="Standard Code Style">
-	</a>
+    <img src="https://github.com/chapmankyle/emoji-set/actions/workflows/test.yml/badge.svg?branch=master" alt="Test Status">
+    <img src="https://img.shields.io/npm/v/emoji-set" alt="Version">
+    <img src="https://img.shields.io/bundlephobia/min/emoji-set" alt="Size">
+    <a href="https://standardjs.com">
+        <img src="https://img.shields.io/badge/code%20style-standard-%23f3df49" alt="Standard Code Style">
+    </a>
 </p>
 
 Emoji library with functions to allow for searching by emoji, group or keyword :mag:
@@ -21,23 +21,26 @@ npm install emoji-set --save
 
 ## Usage :cd:
 
-To use this package, you can import it the following ways:
+To get started, you can import the package using two methods:
 ```js
 // ES6 import
 import EmojiSet from 'emoji-set'
 
-// CommonJS import
-var EmojiSet = require('emoji-set')
+// or CommonJS import
+const EmojiSet = require('emoji-set')
 ```
 
 ## Methods :card_file_box:
 
-### `getAll()`
+### `getAll(onlyEmoji?: boolean | undefined)`
 Returns the full set of emojis available.
 
-*Example:*
+- `onlyEmoji` : Optional. `true` to only return the emoji, `false` to return all information as well as the emoji. Default is `false`.
+
+*Examples:*
 ```js
-> EmojiSet.getAll()
+console.log(EmojiSet.getAll())
+/* Returns */
 {
   '😀': {
     name: 'grinning face',
@@ -60,13 +63,21 @@ Returns the full set of emojis available.
   ...
 }
 ```
+```js
+console.log(EmojiSet.getAll(true))
+/* Returns */
+[ '😀', '😃', '😄', ... ]
+```
 
-### `getGrouped()`
+### `getGrouped(onlyEmoji?: boolean | undefined)`
 Returns all emojis in their respective groups.
 
-*Example:*
+- `onlyEmoji` : Optional. `true` to only return the emoji, `false` to return all information as well as the emoji. Default is `false`.
+
+*Examples:*
 ```js
-> EmojiSet.getGrouped()
+console.log(EmojiSet.getGrouped())
+/* Returns */
 {
   'Smileys & Emotion': [
     {
@@ -101,13 +112,25 @@ Returns all emojis in their respective groups.
   ...
 }
 ```
+```js
+console.log(EmojiSet.getGrouped(true))
+/* Returns */
+{
+  'Smileys & Emotion': [ '😀', '😃', ... ],
+  'People & Body': [ '👋', '🤚', ... ],
+  ...
+}
+```
 
-### `getKeywords()`
+### `getKeywords(onlyEmoji?: boolean | undefined)`
 Returns all emojis associated with each keyword.
 
-*Example:*
+- `onlyEmoji` : Optional. `true` to only return the emoji, `false` to return all information as well as the emoji. Default is `false`.
+
+*Examples:*
 ```js
-> EmojiSet.getKeywords()
+console.log(EmojiSet.getKeywords())
+/* Returns */
 {
   ...
   'playful': {
@@ -157,6 +180,16 @@ Returns all emojis associated with each keyword.
   ...
 }
 ```
+```js
+console.log(EmojiSet.getKeywords(true))
+/* Returns */
+{
+  ...
+  'playful': [ '😛', '😜', '😝', '👅' ],
+  'quiet': [ '🤫', '🔇', '🔕', '📴' ],
+  ...
+}
+```
 
 ### `searchByGroup(group: string, onlyEmoji?: boolean | undefined)`
 Returns all emojis in the given group.
@@ -166,7 +199,8 @@ Returns all emojis in the given group.
 
 *Examples:*
 ```js
-> EmojiSet.searchByGroup('flags', false)
+console.log(EmojiSet.searchByGroup('flags', false))
+/* Returns */
 [
   {
     emoji: '🏁',
@@ -206,7 +240,8 @@ Returns all emojis in the given group.
 ]
 ```
 ```js
-> EmojiSet.searchByGroup('flags', true)
+console.log(EmojiSet.searchByGroup('flags', true))
+/* Returns */
 [ '🏁', '🚩', '🎌', '🏴', '🏳️', '🏳️‍🌈', '🏴‍☠️' ]
 ```
 
@@ -219,7 +254,8 @@ Returns all emojis relating to the given keyword.
 
 *Examples:*
 ```js
-> EmojiSet.searchByKeyword('perf', true, false)
+console.log(EmojiSet.searchByKeyword('perf', true, false))
+/* Returns */
 {
   '💯': {
     name: 'hundred points',
@@ -234,7 +270,8 @@ Returns all emojis relating to the given keyword.
 }
 ```
 ```js
-> EmojiSet.searchByKeyword('perf', false, false)
+console.log(EmojiSet.searchByKeyword('perf', false, false))
+/* Returns */
 {
   '💯': {
     name: 'hundred points',
@@ -259,10 +296,12 @@ Returns all emojis relating to the given keyword.
 }
 ```
 ```js
-> EmojiSet.searchByKeyword('perf', true, true)
+console.log(EmojiSet.searchByKeyword('perf', true, true))
+/* Returns */
 [ '💯', '👌' ]
 ```
 ```js
-> EmojiSet.searchByKeyword('perf', false, true)
+console.log(EmojiSet.searchByKeyword('perf', false, true))
+/* Returns */
 [ '💯', '👌', '👯', '🤹' ]
 ```

--- a/src/EmojiSet.js
+++ b/src/EmojiSet.js
@@ -30,14 +30,15 @@ module.exports = class EmojiSet {
   /**
    * Searches for emojis by a group (can be partial or a whole word).
    * @param {string} group Group to search for associated emojis.
+   * @param {boolean=} onlyEmoji Optional. `true` to only return the emoji, `false` to return all information as well as the emoji. Default is `false`.
    * @returns {object | null} Emojis associated with the given group, or `null` if no emojis match the group.
    */
-  static searchByGroup (group) {
+  static searchByGroup (group, onlyEmoji = false) {
     const lcGroup = group.toLowerCase()
 
     for (const grp in groupedEmojis) {
       if (grp.toLowerCase().includes(lcGroup)) {
-        return groupedEmojis[grp]
+        return onlyEmoji ? groupedEmojis[grp].map(info => info.emoji) : groupedEmojis[grp]
       }
     }
 

--- a/src/EmojiSet.js
+++ b/src/EmojiSet.js
@@ -7,24 +7,43 @@ const keywordEmojis = require('./keywords.json')
  */
 module.exports = class EmojiSet {
   /**
+   * @param {boolean=} onlyEmoji Optional. `true` to only return the emojis, `false` to return the emojis and their information. Default is `false`.
    * @returns All of the emojis with their associated keywords.
    */
-  static getAll () {
-    return allEmojis
+  static getAll (onlyEmoji = false) {
+    return onlyEmoji ? Object.keys(allEmojis) : allEmojis
   }
 
   /**
-   * @returns Emojis grouped by their types.
+   * @param {boolean=} onlyEmoji Optional. `true` to only return the emojis, `false` to return the emojis and their information. Default is `false`.
+   * @returns {object} Emojis grouped by their types.
    */
-  static getGrouped () {
-    return groupedEmojis
+  static getGrouped (onlyEmoji = false) {
+    if (!onlyEmoji) {
+      return groupedEmojis
+    }
+
+    let result = {}
+    for (const group in groupedEmojis) {
+      result[group] = groupedEmojis[group].map(info => info.emoji)
+    }
+    return result
   }
 
   /**
+   * @param {boolean=} onlyEmoji Optional. `true` to only return the emojis, `false` to return the emojis and their information. Default is `false`.
    * @returns Emojis grouped by keywords.
    */
-  static getKeywords () {
-    return keywordEmojis
+  static getKeywords (onlyEmoji = false) {
+    if (!onlyEmoji) {
+      return keywordEmojis
+    }
+
+    let result = {}
+    for (const keyword in keywordEmojis) {
+      result[keyword] = Object.keys(keywordEmojis[keyword])
+    }
+    return result
   }
 
   /**

--- a/src/EmojiSet.js
+++ b/src/EmojiSet.js
@@ -47,17 +47,37 @@ module.exports = class EmojiSet {
   /**
    * Searches for emojis by a keyword (can be partial or a whole word).
    * @param {string} keyword Keyword to use to find emojis.
+   * @param {boolean=} first Optional. `true` to return the first match, `false` to return all matches. Default is `true`.
+   * @param {boolean=} onlyEmoji Optional. `true` to only return the emoji, `false` to return all information as well as the emoji. Default is `false`.
    * @returns {object | null} Emojis associated with the given keyword, or `null` if no emojis match the keyword.
    */
-  static searchByKeyword (keyword) {
+  static searchByKeyword (keyword, first = true, onlyEmoji = false) {
     const lcKeyword = keyword.toLowerCase()
+    let results = null
 
     for (const key in keywordEmojis) {
+      const ret = onlyEmoji ? Object.keys(keywordEmojis[key]) : keywordEmojis[key]
+
       if (key.startsWith(lcKeyword)) {
-        return keywordEmojis[key]
+        // Return the first match
+        if (first) {
+          return ret
+        }
+
+        // Convert to object if no matches have been found yet
+        if (results == null) {
+          results = onlyEmoji ? [] : {}
+        }
+
+        // Check if we only want emojis or all data
+        if (onlyEmoji) {
+          results = [...results, ret].flat(1)
+        } else {
+          results = Object.assign(results, keywordEmojis[key])
+        }
       }
     }
 
-    return null
+    return results
   }
 }

--- a/src/EmojiSet.js
+++ b/src/EmojiSet.js
@@ -23,7 +23,7 @@ module.exports = class EmojiSet {
       return groupedEmojis
     }
 
-    let result = {}
+    const result = {}
     for (const group in groupedEmojis) {
       result[group] = groupedEmojis[group].map(info => info.emoji)
     }
@@ -39,7 +39,7 @@ module.exports = class EmojiSet {
       return keywordEmojis
     }
 
-    let result = {}
+    const result = {}
     for (const keyword in keywordEmojis) {
       result[keyword] = Object.keys(keywordEmojis[keyword])
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,21 @@
 /**
- * EmojiSet package for working with emojis.
+ * *EmojiSet* package for working with emojis 😎👀✌️.
  *
- * Provides methods for easy access to emojis and searching for specific emojis.
+ * Provides methods that can get all available emojis, get emojis by their groups
+ * or get emojis by their keywords as well as searching by group or keyword.
+ *
+ * To get started, you can import the package using two methods:
+ * ```js
+ * // ES6 import
+ * import EmojiSet from 'emoji-set'
+ * // or CommonJS import
+ * const EmojiSet = require('emoji-set')
+ * ```
+ *
+ * All the methods are static, so they can all be called directly using the
+ * `EmojiSet.` syntax.
+ *
+ * Enjoy! 🥳🎉
  */
 
 module.exports = require('./EmojiSet')

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 /**
- * Entry point of module.
+ * EmojiSet package for working with emojis.
+ *
+ * Provides methods for easy access to emojis and searching for specific emojis.
  */
 
 module.exports = require('./EmojiSet')

--- a/tests/correct.json
+++ b/tests/correct.json
@@ -1,4 +1,5 @@
 {
   "num_emojis": 1418,
-  "num_groups": 9
+  "num_groups": 9,
+  "num_keywords": 2010
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -19,7 +19,10 @@ test('Emoji groups', function (t) {
 test('Searching by group', function (t) {
   const groupPartial = 'ags'
   const groupFull = 'Flags'
+
+  t.plan(2)
   t.equal(Object.keys(EmojiSet.searchByGroup(groupPartial)).length, Object.keys(EmojiSet.searchByGroup(groupFull)).length, 'Same emojis returned for searching by partial or full group.')
+  t.equal(EmojiSet.searchByGroup(groupPartial, true).length, EmojiSet.searchByGroup(groupFull, true).length, 'Same number of only emojis returned for searching by partial or full group.')
   t.end()
 })
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -28,8 +28,12 @@ test('Searching by group', function (t) {
 
 /** Test if keyword search by partial or full keyword results in same emojis */
 test('Searching by keyword', function (t) {
-  const keywordPartial = 'sco'
-  const keywordFull = 'score'
+  const keywordPartial = 'sc'
+  const keywordFull = 'scepticism'
+
+  t.plan(3)
   t.equal(Object.keys(EmojiSet.searchByKeyword(keywordPartial)).length, Object.keys(EmojiSet.searchByKeyword(keywordFull)).length, 'Same emojis returned for searching by partial or full keyword.')
+  t.equal(EmojiSet.searchByKeyword(keywordPartial, true, true).length, EmojiSet.searchByKeyword(keywordFull, true, true).length, 'Same number of only emojis returned for searching by partial or full keyword.')
+  t.notEqual(EmojiSet.searchByKeyword(keywordPartial, false, true).length, EmojiSet.searchByKeyword(keywordPartial, true, true).length, 'Different number of emojis returned when specifying only first match and specifying all matches.')
   t.end()
 })

--- a/tests/index.js
+++ b/tests/index.js
@@ -4,14 +4,30 @@ const EmojiSet = require('../src/EmojiSet')
 /** Test number of total emojis */
 test('Total emojis', function (t) {
   const correct = require('./correct.json')
+
+  t.plan(2)
   t.equal(Object.keys(EmojiSet.getAll()).length, correct.num_emojis, 'Correct number of total emojis.')
+  t.equal(typeof EmojiSet.getAll(true)[0], typeof '', 'Specifying `onlyEmoji` as true results in only emojis.')
   t.end()
 })
 
-/** Test number of emoji groups */
-test('Emoji groups', function (t) {
+/** Test emojis in each group */
+test('Emojis by group', function (t) {
   const correct = require('./correct.json')
+
+  t.plan(2)
   t.equal(Object.keys(EmojiSet.getGrouped()).length, correct.num_groups, 'Correct number of emoji groups.')
+  t.equal(typeof EmojiSet.getGrouped(true)['Smileys & Emotion'][0], typeof '', 'Specifying `onlyEmoji` as true results in only emojis for each group.')
+  t.end()
+})
+
+/** Test emojis for each keyword */
+test('Emojis by keyword', function (t) {
+  const correct = require('./correct.json')
+
+  t.plan(2)
+  t.equal(Object.keys(EmojiSet.getKeywords()).length, correct.num_keywords, 'Correct number of emoji keywords.')
+  t.equal(typeof EmojiSet.getKeywords(true).playful[0], typeof '', 'Specifying `onlyEmoji` as true results in only emojis for each keyword.')
   t.end()
 })
 


### PR DESCRIPTION
# Add
- Parameter `onlyEmoji` to all existing functions, which returns only the emojis (instead of associated information as well)
- Parameter `first` to `searchByKeyword` which returns only the first match when `true` and all matches when `false`
- Test cases for new parameters

# Fix
- Missing test case for `getKeywords` method